### PR TITLE
Fix integration of pytest and setup.py.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,3 +15,7 @@ universal = 1
 
 [aliases]
 release = sdist bdist_wheel
+test = pytest
+
+[tool:pytest]
+addopts = -vv --cov sphinxjp --cov-report term-missing

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,9 @@
 # -*- coding: utf-8 -*-
 import os
 import re
-import sys
 
 from setuptools import setup, find_packages
-from setuptools.command.test import test as TestCommand
 
-
-class PyTest(TestCommand):
-    user_options = [('pytest-args=', 'a', 'Arguments to pass to py.test')]
-
-    def initialize_options(self):
-        TestCommand.initialize_options(self)
-        self.pytest_args = []
-
-    def finalize_options(self):
-        TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
-
-    def run_tests(self):
-        # import here, cause outside the eggs aren't loaded
-        import pytest
-        errno = pytest.main(self.pytest_args)
-        sys.exit(errno)
 
 here = os.path.dirname(__file__)
 version_regex = re.compile(r".*__version__ = '(.*?)'", re.S)
@@ -34,6 +14,10 @@ version = version_regex.match(open(version_script, 'r').read()).group(1)
 
 install_requires = [
     'Sphinx',
+]
+
+setup_requires = [
+    "pytest-runner"
 ]
 
 tests_require = [
@@ -67,7 +51,7 @@ classifiers = [
     "Topic :: Text Processing :: Markup",
 ]
 
-description = 'A sphinx theme for generate gotalk style presentation. #sphinxjp'
+description = 'A sphinx theme for generate gotalk style presentation. #sphinxjp'  # NOQA
 
 setup(
     name='sphinxjp.themes.gopher',
@@ -83,9 +67,9 @@ setup(
     namespace_packages=['sphinxjp', 'sphinxjp.themes'],
     packages=find_packages('src', exclude=['tests']),
     package_dir={'': 'src'},
-    cmdclass={'test': PyTest},
     include_package_data=True,
     install_requires=install_requires,
+    setup_requires=setup_requires,
     tests_require=tests_require,
     entry_points="""
         [sphinx_themes]

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist=py27,py34,py35,py36,py37,pypy,flake8
 
 [testenv]
 commands=
-    {envpython} setup.py test -a "--cov sphinxjp"
+    {envpython} setup.py test
 
 [testenv:py34]
 deps=


### PR DESCRIPTION
This error in CI is due to the old way of integrating pytest and setup.py.
https://travis-ci.org/tell-k/sphinxjp.themes.gopher/jobs/519233731

So I fixed it in the latest way of the following URL.
https://docs.pytest.org/en/latest/goodpractices.html#integrating-with-setuptools-python-setup-py-test-pytest-runner